### PR TITLE
refactor: migrate zone operations to use Immer for immutable updates

### DIFF
--- a/packages/core/src/zones/zone-visibility.ts
+++ b/packages/core/src/zones/zone-visibility.ts
@@ -1,3 +1,4 @@
+import { produce } from "immer";
 import type { PlayerId } from "../types";
 import type { Zone } from "./zone";
 
@@ -19,18 +20,16 @@ export function filterZoneByVisibility(zone: Zone, viewerId: PlayerId): Zone {
       return zone;
     }
     // Non-owner sees config but no cards
-    return {
-      ...zone,
-      cards: [],
-    };
+    return produce(zone, (draft) => {
+      draft.cards = [];
+    });
   }
 
   // Secret zones: no one sees card details
   if (zone.config.visibility === "secret") {
-    return {
-      ...zone,
-      cards: [],
-    };
+    return produce(zone, (draft) => {
+      draft.cards = [];
+    });
   }
 
   return zone;


### PR DESCRIPTION
## Summary

Migrates all zone manipulation functions to use Immer's `produce` for immutable state updates, as required by the core-engine-foundation spec.

## Changes

- **zone-operations.ts**: Replaced manual spread operators with `produce()` for:
  - `addCard()` - Uses `draft.cards.splice()` and `draft.cards.push()`
  - `removeCard()` - Uses `draft.cards.splice()` to remove
  - `draw()` - Uses `produce()` for both deck and hand updates
  - `shuffle()` - Fisher-Yates shuffle within `produce()` draft
  - `mill()` - Uses `produce()` for both zones
  
- **zone-visibility.ts**: Updated `filterZoneByVisibility()` to use `produce()` for clearing cards array in filtered views

## Why This Change?

The spec requires all immutable data manipulation to use Immer for:
- Proper integration with XState state machines
- Better performance through structural sharing
- Cleaner, more maintainable code
- Consistent state management patterns

## Testing

- ✅ All 85 tests passing (100% pass rate)
- ✅ TypeScript strict mode: 0 errors
- ✅ Biome linting: All passing

## Before (Manual Spread)

```typescript
export function addCard(zone: Zone, cardId: CardId): Zone {
  const newCards = [...zone.cards];
  newCards.push(cardId);
  return { ...zone, cards: newCards };
}
```

## After (Immer Produce)

```typescript
export function addCard(zone: Zone, cardId: CardId): Zone {
  return produce(zone, (draft) => {
    draft.cards.push(cardId);
  });
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)