### PR TITLE
fix(one-piece): don't gate search-to-hand on open Character slots

### DIFF
--- a/submodules/one-piece/packages/engine/src/effects/resolution.ts
+++ b/submodules/one-piece/packages/engine/src/effects/resolution.ts
@@ -2780,9 +2780,13 @@ export function resolveEffectChoicePrompt(
         selectedIds.length > maximum ||
         new Set(selectedIds).size !== selectedIds.length ||
         selectedIds.some((instanceId) => !playableEligibleIds.includes(instanceId)) ||
-        selectedIds.filter(
-          (instanceId) => getCardForInstance(state, instanceId).cardType === "character",
-        ).length > openCharacterSlots ||
+        // A search only needs open character slots when it PLAYS what it reveals. Revealing to
+        // hand does not consume board space, and gating it here rejected selections that the
+        // prompt in effects/actions.ts had already marked eligible whenever the board was full.
+        (context.action.revealDestination === "character" &&
+          selectedIds.filter(
+            (instanceId) => getCardForInstance(state, instanceId).cardType === "character",
+          ).length > openCharacterSlots) ||
         player.deck
           .slice(0, context.lookedIds.length)
           .some((instanceId, index) => instanceId !== context.lookedIds[index])

--- a/submodules/one-piece/packages/engine/tests/cards/OP12/086-koala.test.ts
+++ b/submodules/one-piece/packages/engine/tests/cards/OP12/086-koala.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vite-plus/test";
+import { op12Karasu085 } from "../../../../cards/src/cards/OP12/characters/085-karasu.ts";
+import { op12Koala086 } from "../../../../cards/src/cards/OP12/characters/086-koala.ts";
+import { op12NicoRobin087 } from "../../../../cards/src/cards/OP12/characters/087-nico-robin.ts";
+import { op12Koala081 } from "../../../../cards/src/cards/OP12/leaders/081-koala.ts";
+import { OnePieceTestEngine } from "../../../src/index.ts";
+
+describe("OP12-086 Koala", () => {
+  // A search whose `revealDestination` is "hand" must not require an open Character slot: nothing
+  // is being put onto the board. `effectSearchSelection` used to apply
+  // `selectedIds.filter(cardType === "character").length > openCharacterSlots` to every search
+  // regardless of destination, while the prompt built in effects/actions.ts folds
+  // `openCharacterSlots` into `destinationCapacity` only when `revealDestination === "character"`.
+  // With a full Character area the two disagreed, and resolution rejected a card the prompt had
+  // just reported as legal.
+  test("reveals to hand even when the Character area is full", () => {
+    const engine = OnePieceTestEngine.create({
+      leaderCardId: op12Koala081,
+      hand: [op12Koala086],
+      // Four bodies already down; Koala takes the fifth and last slot, so the search resolves with
+      // zero open Character slots.
+      character: [
+        { card: op12Karasu085, playedOnTurn: 0 },
+        { card: op12Karasu085, playedOnTurn: 0 },
+        { card: op12Karasu085, playedOnTurn: 0 },
+        { card: op12Karasu085, playedOnTurn: 0 },
+      ],
+      deck: [op12Karasu085, op12NicoRobin087, op12Koala086, op12Karasu085],
+      activeDon: op12Koala086.cost,
+    });
+    const robinId = engine.findCardInZone("south", "deck", op12NicoRobin087);
+
+    engine.playCard(op12Koala086, "south");
+    expect(
+      engine.getState().players.south.characterArea.filter((slot) => slot !== null),
+    ).toHaveLength(5);
+
+    const search = engine.pendingDecision("effectSearchSelection", "south").steps[0];
+    if (search?.kind !== "selectEntity") throw new Error("Expected Koala's search choice.");
+    // The prompt reports Nico Robin as a legal reveal...
+    expect(search.candidates.find((candidate) => candidate.ref.id === robinId)?.legal).toBe(true);
+
+    // ...so resolving her must be accepted. This threw MoveFailedError before the fix.
+    engine.resolveDecision("effectSearchSelection", { selectedIds: [robinId] }, "south");
+    expect(engine.getView("south").players.south.hand.map((card) => card.instanceId)).toContain(
+      robinId,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

A `search` action whose `revealDestination` is `"hand"` was gated on open **Character** slots. With a
full Character area the engine refused every Character its own prompt had just reported as legal.

Opened as a **draft** per `CONTRIBUTING.md` ("Open an issue or draft PR for behavior changes with
broad impact") — happy to split, reshape, or reduce it to an issue if you'd prefer.

## The bug

`effectSearchSelection` in `packages/engine/src/effects/resolution.ts` rejects a selection when

```js
selectedIds.filter((id) => cardType(id) === "character").length > openCharacterSlots
```

and it applied that test to **every** search, regardless of `revealDestination`. Adding a card to
hand doesn't consume board space, so with 0 open slots the check rejects any Character selection.

**The two halves of the feature disagree.** Prompt creation in `effects/actions.ts` folds
`openCharacterSlots` into `destinationCapacity` *only* when `revealDestination === "character"`:

```js
const destinationCapacity =
  action.revealDestination === "character"
    ? playableEligibleIds.filter(/* stages */).length + openCharacterSlots
    : playableEligibleIds.length;
```

Resolution applied it unconditionally. So the prompt marks a card `enabled: true` **and** lists it in
`resolutionContext.eligibleIds`, and then resolution rejects that exact card with
`"Prompt resolution could not be applied."`

Filters are not involved — `eligibleIds` is correct throughout, and the rejected card is in it.

## Evidence — `OP12-086` Koala

`revealDestination: "hand"`, `remainderPosition: "trash"`. Four bodies down, Koala takes the fifth
slot, `[On Play]` looks at 3:

```
prompt options : Karasu enabled:true | Nico Robin enabled:true | Koala enabled:false
eligibleIds    : [Karasu, Nico Robin]
characterArea  : [c26, c27, c28, c29, c21]      <- full, 0 open slots
resolvePrompt  : selectedIds: [NicoRobin]       <- enabled:true, and in eligibleIds
result         : accepted: false, "Prompt resolution could not be applied."
```

## Scope

**171 of the 185 card definitions with a `search` action reveal to hand.** This fires whenever such
a search would add a Character to hand while the board is full — ordinary mid-game, and invisible to
the current tests because every existing search test starts from an empty board.

## The fix

Gate the slot test on the destination, mirroring `actions.ts`. The `playableEligibleIds` membership
check on the preceding line still constrains a hand reveal, so nothing is loosened for
`revealDestination === "character"`.

## Tests

Adds `packages/engine/tests/cards/OP12/086-koala.test.ts`. Fails without the fix
(`MoveFailedError: Move resolvePrompt failed`), passes with it.

Placed under `tests/cards/**` deliberately, because that is what `vite.config.ts` `test.include`
covers. Koala's existing test at `src/cards/OP12/characters/086-koala.test.ts` is **not** executed —
see the note below.

## Validation

- `pnpm run ci:one-piece:check` — **10/10 tasks successful** across all 5 packages
- `vp check` on both changed files — formatted, no lint or type errors, no new `any`/`unknown`
- engine suite **2631 → 2632** passing (confirmed by removing the new file and re-counting)

## Separate observation: per-card tests under `src/cards/` don't run

Filed separately as #217, with numbers measured on pristine `main`.

Short version: `vite.config.ts` `test.include` covers `tests/cards/**` but not `src/cards/**`, so
**1972** per-card test files never execute — including Koala's own `src/cards` test, which is exactly
why a full Character area was never exercised against a hand reveal. That is why the test in this PR
is a new file under `tests/cards/OP12/` rather than an addition to the existing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
